### PR TITLE
Use member init list for AddrObject

### DIFF
--- a/src/amd/vulkan/addrlib/core/addrobject.cpp
+++ b/src/amd/vulkan/addrlib/core/addrobject.cpp
@@ -59,8 +59,9 @@ AddrObject::AddrObject()
 ***************************************************************************************************
 */
 AddrObject::AddrObject(const AddrClient* pClient)
+	:
+	m_client(*pClient)
 {
-    m_client = *pClient;
 }
 
 /**


### PR DESCRIPTION
It's considered better style and better performance to use the initialization list for initializing m_client.
